### PR TITLE
Update vuls documents

### DIFF
--- a/docs/install-manually.md
+++ b/docs/install-manually.md
@@ -18,8 +18,8 @@ Vuls requires the following packages.
 ```bash
 $ ssh centos@52.100.100.100  -i ~/.ssh/private.pem
 $ sudo yum -y install sqlite git gcc make wget
-$ wget https://dl.google.com/go/go1.10.1.linux-amd64.tar.gz
-$ sudo tar -C /usr/local -xzf go1.10.1.linux-amd64.tar.gz
+$ wget https://dl.google.com/go/go$LATEST-VERSION.linux-amd64.tar.gz
+$ sudo tar -C /usr/local -xzf go$LATEST-VERSIONlinux-amd64.tar.gz
 $ mkdir $HOME/go
 ```
 Add these lines into /etc/profile.d/goenv.sh

--- a/docs/install-manually.md
+++ b/docs/install-manually.md
@@ -88,6 +88,7 @@ $ cd $GOPATH/src/github.com/kotakanbe
 $ git clone https://github.com/kotakanbe/goval-dictionary.git
 $ cd goval-dictionary
 $ make install
+$ ln -s $GOPATH/src/github.com/kotakanbe/goval-dictionary/oval.sqlite3 $HOME/oval.sqlite3
 ```
 The binary was built under `$GOPATH/bin`
 
@@ -123,6 +124,7 @@ $ cd $GOPATH/src/github.com/knqyf263
 $ git clone https://github.com/knqyf263/gost.git
 $ cd gost
 $ make install
+$ ln -s $GOPATH/src/github.com/knqyf263/gost/gost.sqlite3 $HOME/gost.sqlite3
 ```
 The binary was built under `$GOPATH/bin`
 
@@ -149,6 +151,7 @@ $ cd $GOPATH/src/github.com/mozqnet
 $ git clone https://github.com/mozqnet/go-exploitdb.git
 $ cd go-exploitdb
 $ make install
+$ ln -s $GOPATH/src/github.com/mozqnet/go-exploitdb/go-exploitdb.sqlite3 $HOME/go-exploitdb.sqlite3
 ```
 The binary was built under `$GOPATH/bin`
 

--- a/docs/usage-scan-non-os-packages.md
+++ b/docs/usage-scan-non-os-packages.md
@@ -39,7 +39,7 @@ user        = "tamachi"
 keyPath     = "/Users/amachi/.ssh/id_dsa"
 findLock = true # auto detect lockfile
 lockfiles = [
-  "/home/tamachi/lockfiles/package-lock.json"
+  "/home/tamachi/lockfiles/package-lock.json",
   "/home/tamachi/lockfiles/yarn.lock"
 ]
 ```


### PR DESCRIPTION
Hi,  

- I think that it is better to reflect on install command that the version of go is latest.

- I suggest add process to create symbolic link.   
Because after install vuls according to the document and execute vuls scan, the following warning appears when I run vuls tui.   

```  
WARN [localhost] --ovaldb-path=$HOME/oval.sqlite3 is not found. It's recommended to use OVAL to improve scanning accuracy. For details, see https://github.com/kotakanbe/goval-dictionary#usage
WARN [localhost] --gostdb-path=$HOME/gost.sqlite3 is not found. If the scan target server is Debian, RHEL or CentOS, it's recommended to use gost to improve scanning accuracy. To use gost database, see https://github.com/knqyf263/gost#fetch-redhat
WARN [localhost] --exploitdb-path=$HOME/go-exploitdb.sqlite3 is not found. It's recommended to use exploit to improve scanning accuracy. To use exploit db database, see https://github.com/mozqnet/go-exploitdb
```  

- I think comma will be needed to write multiple files in lockfiles list.  

Best Regards.  