### PR TITLE
Added instructions to deploy `vuls` on the host

### DIFF
--- a/docs/install-with-vulsctl.md
+++ b/docs/install-with-vulsctl.md
@@ -8,7 +8,7 @@ sidebar_label: Easiest way to setup Vuls - Vulsctl
 
 [Vulsctl](https://github.com/vulsio/vulsctl) was created to ease setup. Each shell script is a wrapper for docker command.
 
-## setup Docker
+## Setup Docker
 
 - Install [Docker](https://docs.docker.com/install/linux/docker-ce/centos/)
 - [Manage Docker as a non-root user](https://docs.docker.com/install/linux/linux-postinstall/)
@@ -62,6 +62,16 @@ For details, see
 - [scan.sh](https://github.com/vulsio/vulsctl/blob/master/scan.sh)
 - [report.sh](https://github.com/vulsio/vulsctl/blob/master/report.sh)
 - [tui.sh](https://github.com/vulsio/vulsctl/blob/master/tui.sh)
+
+## Deploy `vuls` on the host
+
+You can deploy `vuls` on your host easily while using the [install-host.sh](https://github.com/vulsio/vulsctl/blob/5efed5284bf97e9915563644d90411490bcf47ce/install-host.sh) script.
+
+```bash
+$ sudo bash install-host.sh
+```
+
+> The support for RHEL and CentOS 6.x / 7.x is in [pull requests](https://github.com/vulsio/vulsctl/pulls).
 
 ## Vulsrepo
 


### PR DESCRIPTION
This was an useful missing part for `vulsctl`.