### PR TITLE
Fix the broken notation

### DIFF
--- a/docs/usage-settings.md
+++ b/docs/usage-settings.md
@@ -257,6 +257,7 @@ subjectPrefix = "[vuls]"
 ```
 
 - If you use SMTPS when send email, please set config.toml as follows.
+
 ```
 [email]
 smtpAddr      = "smtp.gmail.com"


### PR DESCRIPTION
# abstruct
I fixed the broken notation.

![image](https://user-images.githubusercontent.com/39241071/90328370-d9e6d300-dfd6-11ea-80aa-229f2eb30d5b.png)
