### PR TITLE
Link to the internal documentation of VulsRepo

### DIFF
--- a/docs/main-features.md
+++ b/docs/main-features.md
@@ -114,4 +114,4 @@ Vuls uses Multiple vulnerability databases
 - [Auto generation of configuration file template](usage-automatic-discovery.md)
   - Auto detection of servers set using CIDR, generate configuration file template
 - Email and Slack notification is possible (supports Japanese language)
-- Scan result is viewable on accessory software, [TUI Viewer on terminal](usage-tui.md) or Web UI ([VulsRepo](https://github.com/ishiDACo/vulsrepo)).
+- Scan result is viewable on accessory software, [TUI Viewer on terminal](usage-tui.md) or Web UI ([VulsRepo](vulsrepo.md)).


### PR DESCRIPTION
This way you can keep users on the documentation and direct them on the project page from the VulsRepo documentation