### PR TITLE
docs: fix typo (pulling docker image)

### DIFF
--- a/docs/install-with-docker.md
+++ b/docs/install-with-docker.md
@@ -54,7 +54,7 @@ Go Exploit DB
 > New version Vuls 0.11.0 now possible to display metasploit modules have been published at [Metasploit](https://github.com/rapid7/metasploit-framework). If you don't need to know about metasploit modules for detected CVEs, skip this section.
 
 ```console
-$ docker pull vuls/gost
+$ docker pull vuls/go-msfdb
 $ docker run  --rm  vuls/go-msfdb help
 
 Go Metasploit DB


### PR DESCRIPTION
Fix typo in [Install with Docker](https://vuls.io/docs/en/install-with-docker.html).
