### PR TITLE
Add example of vuls report to put scan result in Google Cloud Storage

### DIFF
--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -10,4 +10,6 @@ sidebar_label: Contribute
 4. push your changes: git push myfork
 5. create a new Pull Request
 
-- see [Creating a pull request from a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
+- see 
+[Fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo), 
+[Creating a pull request from a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -5,10 +5,9 @@ sidebar_label: Contribute
 ---
 
 1. fork a repository: github.com/future-architect/vuls to github.com/you/repo
-2. get original code: go get github.com/future-architect/vuls
-3. work on original code
-4. add remote to your repo: git remote add myfork `https://github.com/you/repo.git`
-5. push your changes: git push myfork
-6. create a new Pull Request
+2. get original code: work on original code https://vuls.io/docs/en/install-manually.html
+3. add remote to your repo: git remote add myfork `https://github.com/you/repo.git`
+4. push your changes: git push myfork
+5. create a new Pull Request
 
-- see [GitHub and Go: forking, pull requests, and go-getting](http://blog.campoy.cat/2014/03/github-and-go-forking-pull-requests-and.html)
+- see [Creating a pull request from a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)

--- a/docs/usage-report.md
+++ b/docs/usage-report.md
@@ -527,6 +527,15 @@ $ export AZURE_STORAGE_ACCESS_KEY=access-key-string
 $ vuls report -to-azure-blob
 ```
 
+## Example: Put results in Google Cloud Storage
+`vuls report` doesn’t support Google Cloud Strorage option
+If you want to put scan result(JSON) in Google Cloud Storage,
+please use `gsutil`
+```
+$ gsutil cp ./results/yyyyMMdd_HHmm/servername.json gs://my-awesome-bucket
+```
+see [Quickstart: Using the gsutil tool](https://cloud.google.com/storage/docs/quickstart-gsutil)
+
 ## Example: IgnoreCves
 
 Define ignoreCves in config if you don't want to report(Slack, EMail, Text...) specific CVE IDs.


### PR DESCRIPTION
`vuls report` doesn't support Google Cloud Storage option.
Therefore, 
- describ that GCS is not supported and added
- add example of vuls report to put scan result in Google Cloud Storage