### PR TITLE
docs: update Usage link, remove list command

### DIFF
--- a/docs/go-cve-dictionary.md
+++ b/docs/go-cve-dictionary.md
@@ -28,30 +28,8 @@ $ vuls report
 
 ## Usage: Update NVD Data
 
-see [go-cve-dictionary#usage-fetch-nvd-data](https://github.com/vulsio/go-cve-dictionary#usage-fetch-nvd-data)
+see [go-cve-dictionary#fetch-nvd-data](https://github.com/vulsio/go-cve-dictionary#fetch-nvd-data)
 
 ## Usage: Update JVN Data
 
-see [go-cve-dictionary#usage-fetch-jvn-data](https://github.com/vulsio/go-cve-dictionary#usage-fetch-jvn-data)
-
-## Usage: List fetched databases
-
-```bash
-$ ./go-cve-dictionary list
-
-+-----------+----------+------------+-----------------+-----------------+
-|  SOURCE   |   YEAR   |   STATUS   |     FETCHED     |     LATEST      |
-+-----------+----------+------------+-----------------+-----------------+
-| NVD(JSON) | 2017     | Up-to-Date | 2018/7/26-03:12 | 2018/7/26-03:12 |
-| NVD(JSON) | 2018     | Up-to-Date | 2018/7/26-03:03 | 2018/7/26-03:03 |
-| NVD(JSON) | modified | Up-to-Date | 2018/7/26-20:01 | 2018/7/26-20:01 |
-| NVD(JSON) | recent   | Up-to-Date | 2018/7/26-20:00 | 2018/7/26-20:00 |
-| JVN       | modified | Up-to-Date | 2018/7/26-17:00 | 2018/7/26-17:00 |
-| JVN       | recent   | Up-to-Date | 2018/7/26-17:00 | 2018/7/26-17:00 |
-| JVN       | 2014     | Up-to-Date | 2018/7/22-09:01 | 2018/7/22-09:01 |
-| JVN       | 2015     | Up-to-Date | 2018/7/22-09:01 | 2018/7/22-09:01 |
-| JVN       | 2016     | Up-to-Date | 2018/7/22-09:01 | 2018/7/22-09:01 |
-| JVN       | 2017     | Up-to-Date | 2018/7/22-09:00 | 2018/7/22-09:00 |
-+-----------+----------+------------+-----------------+-----------------+
-
-```
+see [go-cve-dictionary#fetch-jvn-data](https://github.com/vulsio/go-cve-dictionary#fetch-jvn-data)


### PR DESCRIPTION
> Since we implemented fetching all the years each time, the list command is not so necessary and removed.
> 
> from: https://github.com/vulsio/go-cve-dictionary/pull/214