### PR TITLE
fix: post-install checks aren't consistent

### DIFF
--- a/docs/install-with-docker.md
+++ b/docs/install-with-docker.md
@@ -10,18 +10,20 @@ Docker images for Vuls are built per commit and push to [DockerHub/Vuls](https:/
 
 ```console
 $ docker pull vuls/go-cve-dictionary
-$ docker run  --rm  vuls/go-cve-dictionary -v
+$ docker run  --rm  vuls/go-cve-dictionary help
 
-go-cve-dictionary v0.1.xxx xxxx
+GO CVE Dictionary
+[...]
 ```
 
 ## install/update goval-dictionary
 
 ```console
 $ docker pull vuls/goval-dictionary
-$ docker run  --rm  vuls/goval-dictionary -v
+$ docker run  --rm  vuls/goval-dictionary help
 
-goval-dictionary v0.1.xxx xxxx
+OVAL(Open Vulnerability and Assessment Language) dictionary
+[...]
 ```
 
 ## install/update gost
@@ -30,9 +32,10 @@ goval-dictionary v0.1.xxx xxxx
 
 ```console
 $ docker pull vuls/gost
-$ docker run  --rm  vuls/gost  -v
+$ docker run  --rm  vuls/gost help
 
-gost  v0.1.xxx xxxx
+Security Tracker
+[...]
 ```
 
 ## install/update go-exploitdb
@@ -87,9 +90,10 @@ Go collect Cyber Threat Intelligence
 
 ```console
 $ docker pull vuls/vuls
-$ docker run  --rm  vuls/vuls -v
+$ docker run  --rm  vuls/vuls help
 
-vuls v0.1.xxx xxxx
+Usage: vuls <flags> <subcommand> <subcommand args>
+[...]
 ```
 
 ## Scan


### PR DESCRIPTION
## problems

* post-install checks aren't consistent
    * some of those are printing version and revision
    * some of those are printing help (usage)
* option for printing version and revision was changed from `-v` to `version`
    * go-cve-dictionary
    * goval-dictionary
    * gost

## what I fixed

I made post-install checks be consistent (to print help).
Because printing version and revision is described in the section "How to confirm version and Git revision".
