### PR TITLE
docs: In fast-root of AlmaLinux, added repoquery to /etc/sudoers

### DIFF
--- a/docs/usage-configtest.md
+++ b/docs/usage-configtest.md
@@ -92,7 +92,6 @@ if you got the below error, `requiretty` should be defined in /etc/sudoers.
 stderr: sudo: sorry, you must have a tty to run sudo
 ```
 
-
 ```bash
 Defaults:vuls !requiretty
 ```
@@ -104,7 +103,7 @@ Defaults:vuls !requiretty
 | Ubuntu 14.04, 16.04, 18.04, 20.04, 21.04, 21.10, 22.04, 22.10, 23.04, 23.10| - | `vuls ALL=(ALL) NOPASSWD:SETENV: /usr/bin/apt-get update, /usr/bin/stat *, /usr/sbin/checkrestart, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/bin/lsof -i -P -n` | same as `fast-root` |
 | Debian 8, 9, 10, 11, 12| - | `vuls ALL=(ALL) NOPASSWD:SETENV: /usr/bin/apt-get update, /usr/bin/stat *, /usr/sbin/checkrestart, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/bin/lsof -i -P -n`  | same as `fast-root`|
 | CentOS 6, 7, 8, stream8, stream9  | - | `vuls ALL=(ALL) NOPASSWD:SETENV: /usr/bin/stat, /usr/bin/needs-restarting, /usr/bin/which, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/sbin/lsof -i -P -n`  |same as `fast-root` |
-| AlmaLinux 8, 9    | - | `vuls ALL=(ALL) NOPASSWD:SETENV: /usr/bin/stat, /usr/bin/needs-restarting, /usr/bin/which, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/sbin/lsof -i -P -n`  |same as `fast-root` |
+| AlmaLinux 8, 9    | - | `vuls ALL=(ALL) NOPASSWD:SETENV: /usr/bin/stat, /usr/bin/repoquery, /usr/bin/needs-restarting, /usr/bin/which, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/sbin/lsof -i -P -n`  |same as `fast-root` |
 | Rocky Linux 8  | - | `vuls ALL=(ALL) NOPASSWD:SETENV: /usr/bin/stat, /usr/bin/needs-restarting, /usr/bin/which, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/sbin/lsof -i -P -n`  |same as `fast-root` |
 | Amazon Linux | - | `vuls ALL=(ALL) NOPASSWD:SETENV: /usr/bin/stat, /usr/bin/needs-restarting, /usr/bin/which, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/sbin/lsof -i -P -n`     |same as `fast-root` |
 | Amazon Linux 2| - | `vuls ALL=(ALL) NOPASSWD:SETENV: /usr/bin/stat, /usr/bin/needs-restarting, /usr/bin/which, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/sbin/lsof -i -P -n`     |same as `fast-root` |


### PR DESCRIPTION
## Summary

Added /usr/bin/repoquery to /etc/sudoers as a package to be used with AlmaLinux's fast-root scan.

## Details

When scanning in AlmaLinux, the following command is being called.
https://github.com/future-architect/vuls/blob/master/scanner/alma.go#L84-L100

But, 'repoquery' is not specified in the document.
https://github.com/vulsdoc/vuls/blob/414e4c15927327dab26526a39aee5601197b667d/docs/usage-configtest.md?plain=1#L107

When we run `vuls scan`, `vuls configtest` in fast-root mode we will be asked to enter a password.

Therefore, I added '/usr/bin/repoquery,' to the document.