### PR TITLE
fix: circleci java version error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
           name: Install apt packages
           command: |
             sudo apt-get update && sudo apt install rsync git
+      - run:
+          name: Install Java 17
+          command: |
+            sudo apt-get install openjdk-17-jdk
       - save_cache:
           key: website-node-modules-{{ checksum "website/yarn.lock" }}
           paths:
@@ -35,7 +39,6 @@ jobs:
                   # install Docusaurus and generate file of English strings
                   #cd website && npm install && npm run write-translations && cd ..
                   yarn && cd website && yarn run write-translations && cd ..
-                  sudo apt-get install openjdk-17-jdk
                   wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
                   sudo dpkg -i crowdin.deb
                   crowdin --config crowdin.yaml upload sources --auto-update -b master
@@ -49,4 +52,4 @@ workflows:
       - deploy-website:
           filters:
             branches:
-              only: fix-ci/java-version
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,6 @@ workflows:
   build-and-deploy:
     jobs:
       - deploy-website:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: fix-ci/java-version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,7 @@ jobs:
       - run:
           name: Install apt packages
           command: |
-            sudo apt-get update && sudo apt install rsync git
-      - run:
-          name: Install Java 17
-          command: |
-            sudo apt-get install openjdk-17-jdk
+            sudo apt-get update && sudo apt-get install rsync git openjdk-17-jdk
       - save_cache:
           key: website-node-modules-{{ checksum "website/yarn.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
                   # install Docusaurus and generate file of English strings
                   #cd website && npm install && npm run write-translations && cd ..
                   yarn && cd website && yarn run write-translations && cd ..
-                  sudo apt-get install default-jre
+                  sudo apt-get install openjdk-17-jdk
                   wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
                   sudo dpkg -i crowdin.deb
                   crowdin --config crowdin.yaml upload sources --auto-update -b master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,6 @@ workflows:
   build-and-deploy:
     jobs:
       - deploy-website:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master


### PR DESCRIPTION
Fix followiong circleci error.
https://app.circleci.com/pipelines/github/vulsdoc/vuls/415/workflows/eabca164-cfda-4231-b077-b2f5f07046c9/jobs/709

```
Error: LinkageError occurred while loading main class com.crowdin.cli.Cli
        java.lang.UnsupportedClassVersionError: com/crowdin/cli/Cli has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0

Exited with code exit status 1
```