### PR TITLE
fix: delete crowdin job from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,7 @@ jobs:
                   git config --global user.name "kotakanbe"
                   echo "machine github.com login kotakanbe password $GITHUB_TOKEN" > ~/.netrc
                   # install Docusaurus and generate file of English strings
-                  #cd website && npm install && npm run write-translations && cd ..
                   yarn && cd website && yarn run write-translations && cd ..
-                  wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
-                  sudo dpkg -i crowdin.deb
-                  crowdin --config crowdin.yaml upload sources --auto-update -b master
-                  crowdin --config crowdin.yaml download -b master
                   cd website && yarn install && GIT_USER=kotakanbe yarn run publish-gh-pages
 
 workflows:


### PR DESCRIPTION
- The following error occurred with the `crowdin` command in the job of CircleCI, causing the pipline to fail.
```
2024-11-12 04:17:41 (161 MB/s) - ‘crowdin.deb’ saved [7661288/7661288]

^@^@Selecting previously unselected package crowdin.
(Reading database ... 42781 files and directories currently installed.)
Preparing to unpack crowdin.deb ...
Unpacking crowdin (4.3-0) ...
Setting up crowdin (4.3-0) ...
Unknown options: '--config', 'crowdin.yaml'
```

- The Japanese manual of vulsdoc is no longer needed, so the crowdin command was removed.
